### PR TITLE
fix issue #77: JIRA-issue regexp

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -1,0 +1,20 @@
+import {jiraIssueRegexp} from '../src/jira/regex'
+
+test('jira regex works', async () => {
+  expect('12321 ISSUE-123456 1231'.match(jiraIssueRegexp)).toEqual([
+    'ISSUE-123456',
+  ])
+  expect('ISSUE_1HI-123456'.match(jiraIssueRegexp)).toEqual([
+    'ISSUE_1HI-123456',
+  ])
+  expect('I1-1'.match(jiraIssueRegexp)).toEqual(['I1-1'])
+  // jira issue key must have a number after -
+  expect('IS-'.match(jiraIssueRegexp)).toEqual(null)
+  expect('IS-B'.match(jiraIssueRegexp)).toEqual(null)
+  // jira issue key must have at least 2 characters before -
+  expect('I-1'.match(jiraIssueRegexp)).toEqual(null)
+  // jira issue key must start with a letter
+  expect('1234-123456'.match(jiraIssueRegexp)).toEqual(null)
+  expect('2022-02'.match(jiraIssueRegexp)).toEqual(null)
+  expect('Numbers 12-52'.match(jiraIssueRegexp)).toEqual(null)
+})

--- a/src/docker/utils.ts
+++ b/src/docker/utils.ts
@@ -1,6 +1,7 @@
 import envCi, {GitLabEnv} from 'env-ci'
 import {getLogger} from '../utils/logger'
 import {ValidState} from '../utils/types'
+import {jiraIssueRegexp} from '../jira/regex'
 
 // Using this type as this has the most supported fields
 const env = envCi() as GitLabEnv
@@ -56,11 +57,11 @@ export async function getIssueKeys(): Promise<string[]> {
   const branchName = getBranchName()
   const commitMessage = await getCommitMessage()
 
-  const fromInput = process.env.JIRA_ISSUES?.match(/(\w+)-(\d+)/g) ?? []
+  const fromInput = process.env.JIRA_ISSUES?.match(jiraIssueRegexp) ?? []
 
-  const fromBranch = branchName?.match(/(\w+)-(\d+)/g) ?? []
+  const fromBranch = branchName?.match(jiraIssueRegexp) ?? []
 
-  const fromCommit = commitMessage?.match(/(\w+)-(\d+)/g) ?? []
+  const fromCommit = commitMessage?.match(jiraIssueRegexp) ?? []
 
   const issueKeys = [...fromInput, ...fromBranch, ...fromCommit].filter(
     (value, index, array) => {

--- a/src/github/utils.ts
+++ b/src/github/utils.ts
@@ -3,6 +3,7 @@ import * as github from '@actions/github'
 import type {PullRequestEvent, PushEvent} from '@octokit/webhooks-types'
 import {getLogger} from '../utils/logger'
 import {ValidState} from '../utils/types'
+import {jiraIssueRegexp} from '../jira/regex'
 
 export function getBranchName(): string | undefined {
   let branchName: string | undefined
@@ -64,11 +65,11 @@ export async function getIssueKeys(): Promise<string[]> {
   const branchName = getBranchName()
   const commitMessage = await getCommitMessage()
 
-  const fromInput = core.getInput('issue')?.match(/(\w+)-(\d+)/g) ?? []
+  const fromInput = core.getInput('issue')?.match(jiraIssueRegexp) ?? []
 
-  const fromBranch = branchName?.match(/(\w+)-(\d+)/g) ?? []
+  const fromBranch = branchName?.match(jiraIssueRegexp) ?? []
 
-  const fromCommit = commitMessage?.match(/(\w+)-(\d+)/g) ?? []
+  const fromCommit = commitMessage?.match(jiraIssueRegexp) ?? []
 
   const issueKeys = [...fromInput, ...fromBranch, ...fromCommit].filter(
     (value, index, array) => {

--- a/src/jira/regex.ts
+++ b/src/jira/regex.ts
@@ -1,0 +1,1 @@
+export const jiraIssueRegexp = /(\p{L}[\p{L}\d_]+)-(\d+)/gu


### PR DESCRIPTION
I got the following error from JIRA:
`"Issue Keys must match the pattern '^\\p{L}[\\p{L}\\p{Digit}_]{1,255}-\\p{Digit}{1,255}$'"`

I built a new regex using that error and wrote a few tests for it.

This will now not fail the github action if you have something like "23D-35D" or "2022-22" in your commit messages etc